### PR TITLE
Don't crash on exceptions in SAX parser

### DIFF
--- a/src/main/java/de/mannheim/ids/clarin/xml/I5Validator.java
+++ b/src/main/java/de/mannheim/ids/clarin/xml/I5Validator.java
@@ -246,7 +246,7 @@ public class I5Validator {
                 errorMap.put(name, handler.getErrorMap());
             return handler.isValid;
         } catch (SAXException se) {
-            throw new RuntimeException(se);
+            return false;
         }
     }
 


### PR DESCRIPTION
Return false like with the DOM parser